### PR TITLE
Build and publish arm64 docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,6 +32,7 @@ jobs:
           push: true
           platforms: |
             linux/amd64
+            linux/arm64
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/matrix-wechat-agent:${{ github.ref_name }}
             ${{ secrets.DOCKERHUB_USERNAME }}/matrix-wechat-agent:latest


### PR DESCRIPTION
Currently the container is only build for amd64.

Needs arm support in the `zixia/wechat` image: https://github.com/huan/docker-wechat/issues/99